### PR TITLE
fix(docs): Fixed constant name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ inject(appWrapper) // <div class="appWrapper" style="--main-color: '#007788', ..
 3. To access your variables in JavaScript or TypeScript:
 
    ```javascript
-   jsConfig.mainText // #007788
+   jsInventar.mainText // #007788
    ```
 
 4. To add them as CSS variable, inject them to a wrapping object:


### PR DESCRIPTION

Renamed `jsConfig` to `jsInventar` to keep consistent with the example.