### PR TITLE
Feature/custom outputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import { makeInventar } from './lib'
 import {
 	camelCase2KebabCase,
+	defaultToCssConfigOutput,
+	defaultToInjectOutput,
+	defaultToJsConfigOutput,
 	injectToRoot,
 	injectToStyle,
 	isDerivative,
@@ -35,6 +38,10 @@ export {
 	isValueObject,
 	// Formatters
 	camelCase2KebabCase,
+	// Default outputs
+	defaultToCssConfigOutput,
+	defaultToInjectOutput,
+	defaultToJsConfigOutput,
 	// Types
 	Inventar,
 	InventarBoundInjector,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { makeInventar } from './lib'
 import {
 	camelCase2KebabCase,
-	defaultToCssConfigOutput,
+	defaultToCssInventarOutput,
 	defaultToInjectOutput,
-	defaultToJsConfigOutput,
+	defaultToJsInventarOutput,
 	injectToRoot,
 	injectToStyle,
 	isDerivative,
@@ -39,9 +39,9 @@ export {
 	// Formatters
 	camelCase2KebabCase,
 	// Default outputs
-	defaultToCssConfigOutput,
+	defaultToCssInventarOutput,
 	defaultToInjectOutput,
-	defaultToJsConfigOutput,
+	defaultToJsInventarOutput,
 	// Types
 	Inventar,
 	InventarBoundInjector,

--- a/src/lib/core/index.spec.ts
+++ b/src/lib/core/index.spec.ts
@@ -1,9 +1,16 @@
 import test from 'ava'
 
-import { config2CssVars, resolveConfig } from '.'
+import { resolveConfig, processOutputs } from '.'
+import { mergeOptionsWithDefaults, EXCLUDE_OUTPUT_SYMBOL } from '../utils'
 
 const SIMPLE_CONFIG = { color: '#f00', anotherColor: () => '#0f0' }
-const SIMPLE_RESOLVED_CONFIG = { primaryColor: '#f00' }
+const MINIMAL_RESOLVED_CONFIG = Object.freeze({ color: '#f00' })
+const CUSTOM_OUTPUT_FUNCTION = inventar =>
+	Object.entries(inventar).reduce((agg, [name, value]) => {
+		agg[`${name}${name}`] = value
+		return agg
+	}, {})
+const EXCLUDE_OUTPUT_FUNCTION = () => EXCLUDE_OUTPUT_SYMBOL
 
 test('resolveConfig', t => {
 	const resolvedConfig = resolveConfig(SIMPLE_CONFIG)
@@ -11,12 +18,34 @@ test('resolveConfig', t => {
 	t.is(Object.isFrozen(resolvedConfig), true)
 })
 
-test('config2CssVars, default options', t => {
-	t.deepEqual(config2CssVars(SIMPLE_RESOLVED_CONFIG).cssInventar, { '--primary-color': '#f00' })
+test('processOutputs, default options', t => {
+	const defaultOutputs = processOutputs(MINIMAL_RESOLVED_CONFIG, mergeOptionsWithDefaults({}))
+	t.deepEqual(Object.keys(defaultOutputs), ['jsInventar', 'cssInventar', 'inject'])
+	t.deepEqual(defaultOutputs.jsInventar, { color: '#f00' })
+	t.deepEqual(defaultOutputs.cssInventar, { '--color': '#f00' })
 })
 
-test('config2CssVars, custom name formatter', t => {
-	t.deepEqual(config2CssVars(SIMPLE_RESOLVED_CONFIG, { js2CssNameFormatter: str => str.toUpperCase() }).cssInventar, {
-		'--PRIMARYCOLOR': '#f00',
-	})
+test('processOutputs, shouldMakeCssInventar === false', t => {
+	const defaultOutputs = processOutputs(
+		MINIMAL_RESOLVED_CONFIG,
+		mergeOptionsWithDefaults({ shouldMakeCssInventar: false })
+	)
+	t.deepEqual(Object.keys(defaultOutputs), ['jsInventar'])
+	t.deepEqual(defaultOutputs.jsInventar, { color: '#f00' })
+})
+
+test('processOutputs, custom output', t => {
+	const output = processOutputs(
+		MINIMAL_RESOLVED_CONFIG,
+		mergeOptionsWithDefaults({ outputs: { myOutput: CUSTOM_OUTPUT_FUNCTION } })
+	)
+	t.deepEqual(output, { myOutput: { colorcolor: '#f00' } })
+})
+
+test('processOutputs, custom output with EXCLUDE_OUTPUT_SYMBOL', t => {
+	const output = processOutputs(
+		MINIMAL_RESOLVED_CONFIG,
+		mergeOptionsWithDefaults({ outputs: { myOutput: CUSTOM_OUTPUT_FUNCTION, excludedOutput: EXCLUDE_OUTPUT_FUNCTION } })
+	)
+	t.deepEqual(output, { myOutput: { colorcolor: '#f00' } })
 })

--- a/src/lib/core/index.ts
+++ b/src/lib/core/index.ts
@@ -2,8 +2,8 @@ import { Inventar, InventarConfig, InventarOptions } from '../../types'
 import { resolveDependencies } from './resolveDependencies'
 import { isOutputFunction, EXCLUDE_OUTPUT_SYMBOL } from '../utils'
 
-export const resolveConfig = (rawConfig: InventarConfig) => {
-	const resolvedConfig = resolveDependencies(rawConfig)
+export const resolveConfig = (rawConfig: InventarConfig, options?: InventarOptions) => {
+	const resolvedConfig = resolveDependencies(rawConfig, options)
 
 	return Object.freeze(resolvedConfig)
 }
@@ -11,7 +11,12 @@ export const resolveConfig = (rawConfig: InventarConfig) => {
 export const processOutputs = (config: Inventar, options: InventarOptions) =>
 	Object.entries(options.outputs).reduce((agg, [outputName, outputConfig]) => {
 		const outputFunction = isOutputFunction(outputConfig) ? outputConfig : outputConfig.outputFunction
-		const processedOutput = outputFunction(config, options)
+		const outputTransformers = isOutputFunction(outputConfig) ? [] : outputConfig?.transformers
+		const transformOutputOptions = { ...options, preTransformers: [], postTransformers: outputTransformers }
+		const transformedConfig =
+			outputTransformers && outputTransformers.length ? resolveConfig(config, transformOutputOptions) : config
+
+		const processedOutput = outputFunction(transformedConfig, options)
 		if (processedOutput !== EXCLUDE_OUTPUT_SYMBOL) {
 			agg[outputName] = processedOutput
 		}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,13 +1,11 @@
 import { InventarConfig, InventarMakerOutput, InventarOptions } from '../types'
-import { config2CssVars, resolveConfig } from './core'
+import { processOutputs, resolveConfig } from './core'
 import { mergeOptionsWithDefaults } from './utils'
 
 export const makeInventar = (config: InventarConfig, options: InventarOptions = {}): InventarMakerOutput => {
 	const optionsWithDefaults = mergeOptionsWithDefaults(options)
-	const jsInventar = resolveConfig(config)
-	const cssInventarObject = optionsWithDefaults.shouldMakeCssInventar
-		? config2CssVars(jsInventar, optionsWithDefaults)
-		: {}
+	const inventar = resolveConfig(config)
+	const outputs = processOutputs(inventar, optionsWithDefaults)
 
-	return { jsInventar, ...cssInventarObject }
+	return outputs
 }

--- a/src/lib/utils/index.spec.ts
+++ b/src/lib/utils/index.spec.ts
@@ -1,8 +1,8 @@
 import test from 'ava'
 
 import {
+	defaultToInjectOutput,
 	DEFAULT_OPTIONS,
-	injectToStyle,
 	isBoundInjector,
 	isDerivative,
 	isEntryTuple,
@@ -11,7 +11,7 @@ import {
 	isValueTransformersOnlyObject,
 	mergeOptionsWithDefaults,
 } from '.'
-import { config2CssVars, resolveConfig } from '../core'
+import { resolveConfig } from '../core'
 
 test('mergeOptionsWithDefaults, empty object', t => {
 	t.deepEqual(mergeOptionsWithDefaults({}), DEFAULT_OPTIONS)
@@ -40,10 +40,14 @@ test('isDerivative', t => {
 })
 
 test('Default injector function', t => {
-	const myInventar = config2CssVars(resolveConfig({ oneParam: 1 }))
+	const myInventar = resolveConfig({ oneParam: 1 })
+	const defaultInjector = defaultToInjectOutput(myInventar, DEFAULT_OPTIONS)
 	const domEl = document.createElement('div')
 
-	injectToStyle(myInventar.cssInventar, domEl)
+	if (isBoundInjector(defaultInjector)) {
+		defaultInjector(domEl)
+	}
+
 	const domElementStyle = domEl.getAttribute('style')
 	t.is(domElementStyle, '--one-param: 1')
 })

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -3,7 +3,9 @@ import {
 	InventarBoundInjector,
 	InventarDerivativeValue,
 	InventarEntryTuple,
+	InventarExcludeObject,
 	InventarOptions,
+	InventarOutputFunction,
 	InventarRawValueObject,
 	InventarRawValueObjectWithValue,
 	InventarRawValueTransformersOnlyObject,
@@ -12,6 +14,8 @@ import {
 	InventarTransformerObject,
 	InventarValue,
 } from '../../types'
+
+export const EXCLUDE_OUTPUT_SYMBOL: InventarExcludeObject = Symbol ? Symbol('EXCLUDE_OUTPUT') : {}
 
 export const camelCase2KebabCase = (str: string) => str.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase()
 const cssVars2StyleString = (config: Inventar) =>
@@ -30,14 +34,48 @@ export const injectToRoot = (formattedConfig: Inventar) => {
 	formattedConfigPairs.forEach(([name, value]) => document.documentElement.style.setProperty(name, String(value)))
 }
 
+export const config2CssVars = (config: Inventar, { js2CssNameFormatter }: InventarOptions = {}) => {
+	const resolvedCssVars = Object.entries(config).reduce((agg, [name, value]) => {
+		const cssVarName = `--${js2CssNameFormatter(name)}`
+		agg[cssVarName] = value
+		return agg
+	}, {} as Inventar)
+
+	return Object.freeze(resolvedCssVars)
+}
+
+export const defaultToJsConfigOutput: InventarOutputFunction<Inventar> = (inventar: Inventar) => inventar
+export const defaultToCssConfigOutput: InventarOutputFunction<Inventar> = (
+	config: Inventar,
+	options: InventarOptions
+) => (options.shouldMakeCssInventar ? config2CssVars(config, options) : EXCLUDE_OUTPUT_SYMBOL)
+export const defaultToInjectOutput: InventarOutputFunction<InventarBoundInjector> = (
+	config: Inventar,
+	options: InventarOptions
+) => {
+	if (!options.shouldMakeCssInventar) {
+		return EXCLUDE_OUTPUT_SYMBOL
+	}
+	const cssInventar = config2CssVars(config, options)
+	const inject: InventarBoundInjector = options.cssVarsInjector.bind(null, cssInventar)
+
+	return inject
+}
+
 export const DEFAULT_OPTIONS: InventarOptions = {
 	cssVarsInjector: injectToStyle,
 	js2CssNameFormatter: camelCase2KebabCase,
+	outputs: {
+		jsInventar: defaultToJsConfigOutput,
+		cssInventar: defaultToCssConfigOutput,
+		inject: defaultToInjectOutput,
+	},
 	shouldMakeCssInventar: true,
 }
 
 export const mergeOptionsWithDefaults = (options: InventarOptions) =>
 	({ ...DEFAULT_OPTIONS, ...options } as InventarOptions)
+
 export const isDerivative = (val?: any): val is InventarDerivativeValue => val?.constructor === Function
 export const isValueWithValueObject = (val?: any): val is InventarRawValueObjectWithValue =>
 	Object.keys(val).includes('value')
@@ -53,3 +91,4 @@ export const isTransformer = (val?: any): val is InventarTransformer => val?.con
 export const isTransformerObject = (val?: any): val is InventarTransformerObject => isTransformer(val?.transformer)
 export const isTesterFunction = (val?: any): val is InventarTesterFunction => val?.constructor === Function
 export const isBoundInjector = (val?: any): val is InventarBoundInjector => val?.constructor === Function
+export const isOutputFunction = (val?: any): val is InventarOutputFunction<any> => val?.constructor === Function

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -44,8 +44,8 @@ export const config2CssVars = (config: Inventar, { js2CssNameFormatter }: Invent
 	return Object.freeze(resolvedCssVars)
 }
 
-export const defaultToJsConfigOutput: InventarOutputFunction<Inventar> = (inventar: Inventar) => inventar
-export const defaultToCssConfigOutput: InventarOutputFunction<Inventar> = (
+export const defaultToJsInventarOutput: InventarOutputFunction<Inventar> = (inventar: Inventar) => inventar
+export const defaultToCssInventarOutput: InventarOutputFunction<Inventar> = (
 	config: Inventar,
 	options: InventarOptions
 ) => (options.shouldMakeCssInventar ? config2CssVars(config, options) : EXCLUDE_OUTPUT_SYMBOL)
@@ -66,8 +66,8 @@ export const DEFAULT_OPTIONS: InventarOptions = {
 	cssVarsInjector: injectToStyle,
 	js2CssNameFormatter: camelCase2KebabCase,
 	outputs: {
-		jsInventar: defaultToJsConfigOutput,
-		cssInventar: defaultToCssConfigOutput,
+		jsInventar: defaultToJsInventarOutput,
+		cssInventar: defaultToCssInventarOutput,
 		inject: defaultToInjectOutput,
 	},
 	shouldMakeCssInventar: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,16 +38,21 @@ export type InventarBoundInjector = (domEl?: HTMLElement) => void
 export type InventarConfig = Record<string, InventarConfigValue>
 export type Inventar = Record<string, InventarValue>
 
+export type InventarExcludeObject = symbol | Record<string, unknown>
+export type InventarOutputFunction<T> = (config: Inventar, options?: InventarOptions) => T | InventarExcludeObject
+
+export interface InventarOutputOptions {
+	outputFunction: InventarOutputFunction<any>
+	transformers?: InventarTransformersSequence
+}
+
 export interface InventarOptions {
 	js2CssNameFormatter?: (jsName: string) => string
 	cssVarsInjector?: InventarInjector
+	outputs?: Record<string, InventarOutputFunction<any> | InventarOutputOptions>
 	preTransformers?: InventarTransformersSequence
 	postTransformers?: InventarTransformersSequence
 	shouldMakeCssInventar?: boolean
 }
 
-export interface InventarMakerOutput {
-	cssInventar?: Inventar
-	inject?: InventarBoundInjector
-	jsInventar: Inventar
-}
+export type InventarMakerOutput = Record<string, any>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,7 +41,7 @@ export type Inventar = Record<string, InventarValue>
 export type InventarExcludeObject = symbol | Record<string, unknown>
 export type InventarOutputFunction<T> = (config: Inventar, options?: InventarOptions) => T | InventarExcludeObject
 
-export interface InventarOutputOptions {
+export interface InventarOutputObject {
 	outputFunction: InventarOutputFunction<any>
 	transformers?: InventarTransformersSequence
 }
@@ -49,7 +49,7 @@ export interface InventarOutputOptions {
 export interface InventarOptions {
 	js2CssNameFormatter?: (jsName: string) => string
 	cssVarsInjector?: InventarInjector
-	outputs?: Record<string, InventarOutputFunction<any> | InventarOutputOptions>
+	outputs?: Record<string, InventarOutputFunction<any> | InventarOutputObject>
 	preTransformers?: InventarTransformersSequence
 	postTransformers?: InventarTransformersSequence
 	shouldMakeCssInventar?: boolean


### PR DESCRIPTION
This PR adds support for custom outputs.

The options object now supports a new `outputs` field, which includes an object. The object's keys are the outputs' names (default: `jsInventar`, `cssInventar`, `'inject') and the values are either a function or an object containing a function and an optional array of output-specific transformers.

An output function accepts a ready Inventar config and options (`preTransformers` and `postTransformers` being ignored in favor of output-specific transformers).

The default output has been converted to the new options' format. There might be slight performance costs.